### PR TITLE
Fix assertion failure after upgrading to Xcode 6+

### DIFF
--- a/screen-recording/main.m
+++ b/screen-recording/main.m
@@ -56,6 +56,8 @@ void printOwners() {
     }
 }
 
+extern void CGSInitialize(void);
+
 // Locate window by owner name and return found, pid, bounds, and displayID.
 //   found     - (NSNumber) 1 if we've found the window, 0 otherwise.
 //   pid       - (NSNumber) the process id
@@ -71,7 +73,7 @@ NSDictionary* findWindowBoundsAndPid(NSString* ownerName) {
         if ([[info objectForKey:(NSString *)kCGWindowOwnerName] isEqualToString:ownerName] &&
             ![[info objectForKey:(NSString *)kCGWindowName] isEqualToString:@""]) {
             NSNumber* pid = [info objectForKey:(id)kCGWindowOwnerPID];
-
+            CGSInitialize();
             windowID = [[info objectForKey:(NSString *)kCGWindowNumber] unsignedIntValue];
             CGRectMakeWithDictionaryRepresentation((CFDictionaryRef)objc_unretainedPointer([info objectForKey:(NSString *)kCGWindowBounds]), &windowRect);
             CGGetDisplaysWithRect(windowRect, 1, &displayID, NULL);


### PR DESCRIPTION
By reversing the Core Graphics framework, the function CGS_REQUIRE_INIT will checking an internal variable "did_initialize".
And the value of "did_initialize" will be set in function "CGSInitialize"
